### PR TITLE
Set the application baseURL to allow the use of SSL-terminating reverse proxies with SAML SSO

### DIFF
--- a/root/var/www/simplesamlphp/config/config.php
+++ b/root/var/www/simplesamlphp/config/config.php
@@ -35,7 +35,7 @@ $config = [
      * The 'application' configuration array groups a set configuration options
      * relative to an application protected by SimpleSAMLphp.
      */
-    //'application' => [
+    'application' => [
     /*
      * The 'baseURL' configuration option allows you to specify a protocol,
      * host and optionally a port that serves as the canonical base for all
@@ -50,8 +50,8 @@ $config = [
      * need to compute the right URLs yourself and pass them dynamically
      * to SimpleSAMLphp's API.
      */
-    //    'baseURL' => $auth['saml']['ssp_host'],
-    //],
+        'baseURL' => $auth['saml']['ssp_host'],
+    ],
 
     /*
      * The following settings are *filesystem paths* which define where


### PR DESCRIPTION
From the SimpleSAMLphp config

> The 'baseURL' configuration option allows you to specify a protocol, host and optionally a port that serves as the canonical base for all your application's URLs. This is useful when the environment observed in the server differs from the one observed by end users, for example, when using a load balancer to offload TLS.

In my case it was impossible to use MRBS with a *loadbalancer to offload TLS* and there was possibility to enable this easily.