### PR TITLE
Improve documentation for SAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ $auth['saml']['attr']['surname'] = '<surname attribute>';
 $auth['saml']['admin']['<group list attribute>'] = ['<admin group>'];
 ```
 
+If you want to use SAML authentication with mrbs behind a SSL reverse proxy you need to set
+```php
+$auth['saml']['ssp_secure_cookie'] = true;
+```
+
 - You can test the authentication here: `mrbs.company.com/simplesaml/module.php/core/authenticate.php`. It will also show you all transmitted attributes.
 - The admin password for simplesaml can be found in `config/keys/secretsalt`.
 - You need to add the redirect URL `https://mrbs.company.com/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp`

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To configure SAML Authentication, you need to add these lines to your config.inc
 ```php
 $auth['type'] = 'saml';
 $auth['session'] = 'saml';
-$auth['saml']['ssp_host'] = '<host of your mrbs, eg https://mrbs.company.com/>';
+$auth['saml']['ssp_host'] = '<host of your mrbs, eg https://mrbs.company.com/, with a trailing slash>';
 $auth['saml']['ssp_idp'] = '<issuer of your SAML idp>';
 $auth['saml']['ssp_entity_id'] = '<client id of yout SAML idp>';
 $auth['saml']['ssp_single_sign_on_service'] = '<single sign on endpoint of your SAML idp>';


### PR DESCRIPTION
* Document the existence of `$auth['saml']['ssp_secure_cookie']` fe279e9d2dbaa672f3b2c5130183f90ab7c64147
* Document the need for a trailing slash in `$auth['saml']['ssp_host']` 96122affc8166389365c164e7a1455fcbdd842e2
