### PR TITLE
Update MRBS code version to 1.12.1 and SimpleSAMLphp version to 2.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN \
 
   echo "**** extract only folder 'web' ****" && \
   tar -C /app/www/public --strip-components=2 -zxvf /tmp/mrbs.tar.gz $(tar --exclude="*/*" -tf /tmp/mrbs.tar.gz)web && \
+  sed -r -i 's/(public function .*\)\)$)/\1 : void/' /app/www/public/lib/MRBS/Logger.php && \
   mkdir -p /usr/share/mrbs && \
   tar -C /usr/share/mrbs --wildcards --strip-components=1 -zxvf /tmp/mrbs.tar.gz $(tar --exclude="*/*" -tf /tmp/mrbs.tar.gz)tables.*.sql && \
   echo "**** cleanup ****" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.21
 
 # versions
-ARG MRBS_RELEASE=v1.11.6
-ARG SIMPLESAMLPHP_RELEASE=1.19.9
-ARG MODERN_MRBS_THEME_RELEASE=v0.5.1
+ARG MRBS_RELEASE=1.12.1
+ARG SIMPLESAMLPHP_RELEASE=2.4.4
+ARG MODERN_MRBS_THEME_RELEASE=0.5.1
 
 LABEL maintainer="Dorian Zedler <mail@dorian.im>"
 
@@ -42,7 +42,7 @@ RUN \
   rm -rf /app/www && \
   mkdir -p /app/www/public && \
   curl -o /tmp/mrbs.tar.gz -L \
-    "https://github.com/meeting-room-booking-system/mrbs-code/archive/${MRBS_RELEASE}.tar.gz" && \
+    "https://github.com/meeting-room-booking-system/mrbs-code/archive/v${MRBS_RELEASE}.tar.gz" && \
 
   echo "**** extract only folder 'web' ****" && \
   tar -C /app/www/public --strip-components=2 -zxvf /tmp/mrbs.tar.gz $(tar --exclude="*/*" -tf /tmp/mrbs.tar.gz)web && \
@@ -56,7 +56,7 @@ RUN \
   mkdir -p /app/www/simplesamlphp && \
   curl -o \
   /tmp/simplesamlphp.tar.gz -L \
-    "https://github.com/simplesamlphp/simplesamlphp/releases/download/v${SIMPLESAMLPHP_RELEASE}/simplesamlphp-${SIMPLESAMLPHP_RELEASE}.tar.gz" && \
+    "https://github.com/simplesamlphp/simplesamlphp/releases/download/v${SIMPLESAMLPHP_RELEASE}/simplesamlphp-${SIMPLESAMLPHP_RELEASE}-slim.tar.gz" && \
   echo "**** extract simplesamlphp ****" && \
   tar -C /app/www/simplesamlphp --strip-components=1 -zxvf /tmp/simplesamlphp.tar.gz && \
   echo "**** cleanup ****" && \
@@ -66,7 +66,7 @@ RUN \
   echo "**** fetch modern-mrbs-theme ****" && \
   mkdir -p /app/www/public/Themes/modern && \
   curl -o /tmp/modern-mrbs-theme.tar.gz -L \
-    "https://github.com/dorianim/modern-mrbs-theme/archive/${MODERN_MRBS_THEME_RELEASE}.tar.gz" && \
+    "https://github.com/dorianim/modern-mrbs-theme/archive/v${MODERN_MRBS_THEME_RELEASE}.tar.gz" && \
   echo "**** extract only folder 'modern' ****" && \
   tar -C /app/www/public/Themes/modern --strip-components=2 -zxvf /tmp/modern-mrbs-theme.tar.gz $(tar --exclude="*/*" -tf /tmp/modern-mrbs-theme.tar.gz)modern && \
   \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+
+mrbs_version := $(shell curl --silent "https://api.github.com/repos/meeting-room-booking-system/mrbs-code/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+sso_version := $(shell curl --silent "https://api.github.com/repos/simplesamlphp/simplesamlphp/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+theme_version := $(shell curl --silent "https://api.github.com/repos/dorianim/modern-mrbs-theme/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+
+default: version
+
+all: version
+
+version:
+	@sed -r -i "s/^(ARG MRBS_RELEASE)=.*/\1=$(mrbs_version)/" Dockerfile
+	@sed -r -i "s/^(ARG SIMPLESAMLPHP_RELEASE)=.*/\1=$(sso_version)/" Dockerfile
+	@sed -r -i "s/^(ARG MODERN_MRBS_THEME_RELEASE)=.*/\1=$(theme_version)/" Dockerfile
+

--- a/root/app/www/public/Themes/blue/custom.css
+++ b/root/app/www/public/Themes/blue/custom.css
@@ -1,39 +1,50 @@
 
-a:link {color: #000000;}
-a:visited {color: #000000;}
-a:hover {color: #000000;}
+nav.view a.selected {
+  background: #c2e7ff;
+  color: #000000;
+}
 
-nav.view a.selected {background: #c2e7ff; color: #000000;}
-nav.view a:hover {background: #e4e7ec; color: #000000;}
+nav.view a:hover {
+  background: #e4e7ec;
+  color: #000000;
+}
 
-.color_key > div {color: #ffffff;}
+div.A, div.A a,
+div.B, div.B a,
+div.C, div.C a,
+div.D, div.D a,
+div.E, div.E a,
+div.F, div.F a,
+div.G, div.G a,
+div.H, div.H a,
+div.I, div.I a,
+div.J, div.J a,
+.color_key > div {
+  color: #ffffff;
+}
 
-div.A a {color: #ffffff;}
-div.B a {color: #ffffff;}
-div.C a {color: #ffffff;}
-div.D a {color: #ffffff;}
-div.E a {color: #ffffff;}
-div.F a {color: #ffffff;}
-div.G a {color: #ffffff;}
-div.H a {color: #ffffff;}
-div.I a {color: #ffffff;}
-div.J a {color: #ffffff;}
+.banner {
+  background-color: #f8fafd;
+  border-color: #f8fafd;
+}
 
-.banner {background-color: #f8fafd; border-color: #f8fafd;}
-
-table.dataTable.display tbody tr.odd {background-color: #f8fafd;}
-table.dataTable.display tbody tr.even {background-color: #ffffff;}
-
+table.dataTable.display tbody tr.odd,
 table.dataTable.display tbody tr.odd > .sorting_1,
-table.dataTable.order-column.stripe tbody tr.odd > .sorting_1 {background-color: #f8fafd;}
 table.dataTable.display tbody tr.odd > .sorting_2,
-table.dataTable.order-column.stripe tbody tr.odd > .sorting_2 {background-color: #f8fafd;}
 table.dataTable.display tbody tr.odd > .sorting_3,
-table.dataTable.order-column.stripe tbody tr.odd > .sorting_3 {background-color: #f8fafd;}
+table.dataTable.order-column.stripe tbody tr.odd > .sorting_1,
+table.dataTable.order-column.stripe tbody tr.odd > .sorting_2,
+table.dataTable.order-column.stripe tbody tr.odd > .sorting_3 {
+  background-color: #f8fafd;
+}
+
+table.dataTable.display tbody tr.even,
 table.dataTable.display tbody tr.even > .sorting_1,
-table.dataTable.order-column.stripe tbody tr.even > .sorting_1  {background-color: #ffffff;}
 table.dataTable.display tbody tr.even > .sorting_2,
-table.dataTable.order-column.stripe tbody tr.even > .sorting_2 {background-color: #ffffff;}
 table.dataTable.display tbody tr.even > .sorting_3,
-table.dataTable.order-column.stripe tbody tr.even > .sorting_3 {background-color: #ffffff;}
+table.dataTable.order-column.stripe tbody tr.even > .sorting_1,
+table.dataTable.order-column.stripe tbody tr.even > .sorting_2,
+table.dataTable.order-column.stripe tbody tr.even > .sorting_3 {
+  background-color: #ffffff;
+}
 

--- a/root/app/www/public/Themes/blue/custom.css
+++ b/root/app/www/public/Themes/blue/custom.css
@@ -1,0 +1,39 @@
+
+a:link {color: #000000;}
+a:visited {color: #000000;}
+a:hover {color: #000000;}
+
+nav.view a.selected {background: #c2e7ff; color: #000000;}
+nav.view a:hover {background: #e4e7ec; color: #000000;}
+
+.color_key > div {color: #ffffff;}
+
+div.A a {color: #ffffff;}
+div.B a {color: #ffffff;}
+div.C a {color: #ffffff;}
+div.D a {color: #ffffff;}
+div.E a {color: #ffffff;}
+div.F a {color: #ffffff;}
+div.G a {color: #ffffff;}
+div.H a {color: #ffffff;}
+div.I a {color: #ffffff;}
+div.J a {color: #ffffff;}
+
+.banner {background-color: #f8fafd; border-color: #f8fafd;}
+
+table.dataTable.display tbody tr.odd {background-color: #f8fafd;}
+table.dataTable.display tbody tr.even {background-color: #ffffff;}
+
+table.dataTable.display tbody tr.odd > .sorting_1,
+table.dataTable.order-column.stripe tbody tr.odd > .sorting_1 {background-color: #f8fafd;}
+table.dataTable.display tbody tr.odd > .sorting_2,
+table.dataTable.order-column.stripe tbody tr.odd > .sorting_2 {background-color: #f8fafd;}
+table.dataTable.display tbody tr.odd > .sorting_3,
+table.dataTable.order-column.stripe tbody tr.odd > .sorting_3 {background-color: #f8fafd;}
+table.dataTable.display tbody tr.even > .sorting_1,
+table.dataTable.order-column.stripe tbody tr.even > .sorting_1  {background-color: #ffffff;}
+table.dataTable.display tbody tr.even > .sorting_2,
+table.dataTable.order-column.stripe tbody tr.even > .sorting_2 {background-color: #ffffff;}
+table.dataTable.display tbody tr.even > .sorting_3,
+table.dataTable.order-column.stripe tbody tr.even > .sorting_3 {background-color: #ffffff;}
+

--- a/root/app/www/public/Themes/blue/styling.inc
+++ b/root/app/www/public/Themes/blue/styling.inc
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+namespace MRBS;
+
+// DEFAULT THEME
+
+// ***** COLOURS ************************
+// Colours used in MRBS.    All the colours are defined here as PHP variables
+
+$body_background_color          = "#f8fafd";    // background colour for the main body
+$standard_font_color            = "#444746";    // default font color
+$header_font_color              = "#1f1f1f";    // font color for text in headers
+$highlight_font_color           = "#ff0066";    // used for highlighting text (eg links, errors)
+$color_key_font_color           = "#000000";    // used in the colour key table
+
+$banner_back_color              = "#d4e3fb";                // background colour for banner
+$banner_border_color            = "#d4e3fb";                // border colour for banner
+$banner_font_color              = $header_font_color;       // font colour for banner
+$banner_nav_hover_color         = '#0099cc';    // background colour when header links are hovered over
+
+$minical_view_color             = "#2b3a42";    // used for highlighting the dates in the current view
+$minical_today_color            = "#bdd4de";    // used for highlighting today
+
+$header_back_color              = $banner_back_color;  // background colour for headers
+$flatpickr_highlight_color      = "#0b57d0";           // used for highlighting the date
+
+$admin_table_header_back_color  = $header_back_color;     // background colour for header and also border colour for table cells
+$admin_table_header_sep_color   = $body_background_color; // vertical separator colour in header
+$admin_table_header_font_color  = $header_font_color;     // font colour for header
+$admin_table_border_color       = "#C3CCD3";
+
+$main_table_border_color        = "#dddddd";    // border colour for day/week/month tables - outside
+$main_table_header_border_color = "#dddddd";    // border colour for day/week/month tables - header
+$main_table_body_h_border_color = "#ffffff";    // border colour for day/week/month tables - body, horizontal
+$main_table_body_v_border_color = "#e4e4e4";    // border colour for day/week/month tables - body, vertical
+$main_table_month_color         = "#ffffff";    // background colour for days in the month view
+$main_table_month_weekend_color = "#f4f4f4";    // background colour for weekends in the month view
+$main_table_month_holiday_color = "#e8e8e8";    // background colour for holidays in the month view
+$main_table_month_weekend_holiday_color = "#dfdfdf";    // background colour for weekend holidays in the month view
+$main_table_month_invalid_color = "#d1d9de";    // background colour for invalid days in the month view
+$main_table_slot_invalid_color  = "#d1d9de";    // background colour for invalid slots in the day and week views
+$main_table_slot_private_type_color = "#d1d9de";          // background colour when the type has to kept private
+$main_table_labels_back_color   = $header_back_color;     // background colour for the row labels column
+$timeline_color                 = $header_back_color;
+
+// border colours for the main table when it is printed.     These are used by mrbs-print.css.php
+$main_table_border_color_print        = "#dddddd";    // border colour for the main table (print view)
+$main_table_header_border_color_print = "#dddddd";    // border colour for day/week/month tables - header (print view)
+$main_table_body_h_border_color_print = "#dddddd";    // border colour for day/week/month tables - body, horizontal (print view)
+$main_table_body_v_border_color_print = "#dddddd";    // border colour for day/week/month tables - body, vertical (print view)
+
+// font colours for the main table when it is printed
+$header_font_color_print        = "#0B263B";
+$anchor_link_color_header_print = "#0B263B";
+
+$report_table_border_color      = $standard_font_color;
+$report_h2_border_color         = $banner_back_color;     // border colour for <h2> in report.php
+$report_h3_border_color         = "#879AA8";              // border colour for <h2> in report.php
+
+$search_table_border_color      = $standard_font_color;
+
+$site_faq_entry_border_color    = "#C3CCD3";              // used to separate individual FAQ's in help.php
+
+$anchor_link_color              = "#000000";                   // link color
+$anchor_visited_color           = "#000000";                   // link color (visited)
+$anchor_hover_color             = "#000000";                   // link color (hover)
+
+$anchor_link_color_banner       = $header_font_color;          // link color
+$anchor_visited_color_banner    = $anchor_link_color_banner;   // link color (visited)
+$anchor_hover_color_banner      = $anchor_link_color_banner;   // link color (hover)
+
+$anchor_link_color_header       = $standard_font_color;          // link color
+$anchor_visited_color_header    = $anchor_link_color_header;   // link color (visited)
+$anchor_hover_color_header      = $anchor_link_color_header;   // link color (hover)
+
+$column_hidden_color            = $main_table_month_invalid_color;    // hidden days in the week and month views
+$calendar_hidden_color          = "#dae0e4";                          // hidden days in the mini-cals
+$row_highlight_color            = $banner_back_color;  // used for highlighting a row
+$row_even_color                 = "#ffffff"; // even rows in the day and week views
+$row_odd_color                  = "#f8fafd"; // odd rows in the day and week views
+$row_even_color_weekend         = "#ffffff"; // even rows in the day and week views for weekends
+$row_odd_color_weekend          = "#f8fafd"; // odd rows in the day and week views for weekends
+$row_even_color_holiday         = "#ffffff"; // even rows in the day and week views for holidays
+$row_odd_color_holiday          = "#f8fafd"; // odd rows in the day and week views for holidays
+$row_even_color_weekend_holiday = "#ffffff"; // even rows in the day and week views for weekend holidays
+$row_odd_color_weekend_holiday  = "#f8fafd"; // odd rows in the day and week views for weekend holidays
+
+$zebra_even_color = "#ffffff";  // Colour for even rows in other tables (eg Search, Report and Users)
+$zebra_odd_color  = "#f8fafd";  // Colour for odd rows in other tables (eg Search, Report and Users)
+
+$help_highlight_color           = "#ffe6f0";        // highlighting text on the help page
+
+// Button colours
+$button_color_stops = array('#eeeeee', '#cccccc');  // linear gradient colour stops
+$button_inset_color = 'darkblue';
+
+// These are the colours used for distinguishing between the different types of bookings in the main
+// displays in the day, week and month views
+$color_types = array(
+    'A' => "#3f51b5",  // Blueberry
+    'B' => "#7986cb",  // Lavender
+    'C' => "#f4511e",  // Tangerine
+    'D' => "#e67c73",  // Flamingo
+    'E' => "#33b679",  // Sage
+    'F' => "#f6bf26",  // Banana
+    'G' => "#0b8043",  // Basil
+    'H' => "#d50000",  // Tomato
+    'I' => "#039be5",  // Peacock
+    'J' => "#8e24aa"); // Grape
+
+// colours used for pending.php and bookings awaiting approval
+$outstanding_color         = "#FFF36C";     // font colour for the outstanding reservations message in the header
+$pending_header_back_color = $header_back_color; // background colour for series headers
+$series_entry_back_color   = "#FFFCDA";     // background colour for entries in a series
+$pending_control_color     = "#FFF36C";     // background colour for the series +/- controls in pending.php
+$attention_color           = 'darkorange';  // background colour for the number of bookings awaiting approval
+
+// ***** DIMENSIONS *******************
+$banner_border_width          = '0';  // (px)  border width for the outside of the banner
+$banner_border_cell_width     = '1';  // (px)  border width for the cells of the banner
+$main_table_border_width      = '0';  // (px)  border width for the outside of the main day/week/month tables
+$main_table_cell_border_width = '1';  // (px)  vertical border width for the cells of the main day/week/month tables
+$main_cell_height             = '1.5em';  // height of the cells in the main day/week tables
+
+
+// ***** FONTS ************************
+$standard_font_family  = "Arial, 'Arial Unicode MS', Verdana, sans-serif";
+

--- a/root/app/www/public/Themes/blue/styling.inc
+++ b/root/app/www/public/Themes/blue/styling.inc
@@ -2,7 +2,9 @@
 declare(strict_types=1);
 namespace MRBS;
 
-// DEFAULT THEME
+// BLUE THEME
+
+$custom_css_url = 'Themes/'.$theme.'/custom.css';
 
 // ***** COLOURS ************************
 // Colours used in MRBS.    All the colours are defined here as PHP variables
@@ -41,7 +43,7 @@ $main_table_month_invalid_color = "#d1d9de";    // background colour for invalid
 $main_table_slot_invalid_color  = "#d1d9de";    // background colour for invalid slots in the day and week views
 $main_table_slot_private_type_color = "#d1d9de";          // background colour when the type has to kept private
 $main_table_labels_back_color   = $header_back_color;     // background colour for the row labels column
-$timeline_color                 = $header_back_color;
+$timeline_color                 = "#db372d";
 
 // border colours for the main table when it is printed.     These are used by mrbs-print.css.php
 $main_table_border_color_print        = "#dddddd";    // border colour for the main table (print view)

--- a/root/app/www/public/config.inc.php
+++ b/root/app/www/public/config.inc.php
@@ -36,7 +36,7 @@ $db_persist = false;
 
 // default to blue theme
 $theme = "blue";
-$custom_css_url = 'Themes/'.$theme.'/custom.css';
+//$custom_css_url = 'Themes/'.$theme.'/custom.css';
 
 // default to modern theme
 //$theme = "modern";

--- a/root/app/www/public/config.inc.php
+++ b/root/app/www/public/config.inc.php
@@ -34,8 +34,12 @@ $db_tbl_prefix = "mrbs_";
 // connections if you can.
 $db_persist = false;
 
+// default to blue theme
+$theme = "blue";
+$custom_css_url = 'Themes/'.$theme.'/custom.css';
+
 // default to modern theme
-$theme = "modern";
+//$theme = "modern";
 $disable_menu_items_for_non_admins = ["rooms", "user_list"];
 
 /**********
@@ -63,8 +67,10 @@ $timezone = getenv("TZ") ? getenv("TZ") : "Europe/Berlin";
  *************/
 
 $auth['saml']['ssp_path'] = '/app/www/simplesamlphp';
+$auth['saml']['authsource'] = 'default-sp';
+$auth['saml']['disable_mrbs_session_init'] = false;
 $auth['saml']['ssp_protect_web_interface'] = true;
 $auth['saml']['ssp_secure_cookie'] = false;
-$auth['saml']['authsource'] = 'default-sp';
+$auth['deny_public_access'] = true;
 
 require "/config/www/config.inc.php";

--- a/root/app/www/simplesamlphp/config/authsources.php
+++ b/root/app/www/simplesamlphp/config/authsources.php
@@ -11,8 +11,8 @@ $config = [
         'core:AdminPassword',
     ],
 
-    // An authentication source which can authenticate against both SAML 2.0
-    // and Shibboleth 1.3 IdPs.
+
+    // An authentication source which can authenticate against SAML 2.0 IdPs.
     'default-sp' => [
         'saml:SP',
 
@@ -23,5 +23,17 @@ $config = [
         // The entity ID of the IdP this SP should contact.
         // Can be NULL/unset, in which case the user will be shown a list of available IdPs.
         'idp' => $auth['saml']['ssp_idp'],
+
+        // The URL to the discovery service.
+        // Can be NULL/unset, in which case a builtin discovery service will be used.
+        'discoURL' => null,
+
+        /*
+         * If SP behind the SimpleSAMLphp in IdP/SP proxy mode requests
+         * AuthnContextClassRef, decide whether the AuthnContextClassRef will be
+         * processed by the IdP/SP proxy or if it will be passed to the original
+         * IdP in front of the IdP/SP proxy.
+         */
+        'proxymode.passAuthnContextClassRef' => false,
     ],
 ];

--- a/root/app/www/simplesamlphp/metadata/saml20-idp-remote.php
+++ b/root/app/www/simplesamlphp/metadata/saml20-idp-remote.php
@@ -10,7 +10,17 @@ require '/config/www/config.inc.php';
  * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-remote
  */
 $metadata[$auth['saml']['ssp_idp']] = [
-    'SingleSignOnService' => $auth['saml']['ssp_single_sign_on_service'],
-    'SingleLogoutService' => $auth['saml']['ssp_single_logout_service'],
+    'SingleSignOnService' => [
+        [
+            'Location' => $auth['saml']['ssp_single_sign_on_service'],
+            'Binding'  => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+    ],
+    'SingleLogoutService' => [
+        [
+            'Location'         => $auth['saml']['ssp_single_logout_service'],
+            'Binding'          => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+    ],
     'certData' => $auth['saml']['ssp_cert_data'],
 ];

--- a/root/etc/nginx/http.d/mrbs.conf
+++ b/root/etc/nginx/http.d/mrbs.conf
@@ -20,7 +20,7 @@ server {
     }
 
 	location ^~ /simplesaml {
-		alias /app/www/simplesamlphp/www;
+		alias /app/www/simplesamlphp/public;
 
 		location ~ ^(?<prefix>/simplesaml)(?<phpfile>.+?\.php)(?<pathinfo>/.*)?$ {
 			include          fastcgi_params;


### PR DESCRIPTION
**Update MRBS code version to 1.12.1 and SimpleSAMLphp version to 2.4.4, including new configuration and metadata files. Change the SimpleSAMLphp alias in NGINX from 'www' to 'public'.**

Fix TypeError when using an authentication scheme, eg SAML, that pulls in a later version of Psr\Log\LoggerInterface.  See GitHub Issue https://github.com/meeting-room-booking-system/mrbs-code/issues/3956.

https://simplesamlphp.org/docs/stable/simplesamlphp-upgrade-notes-2.0.html
- Our assets have been moved from the www to the public directory. You will have to update your webserver to reflect this change. 
- Quite some options have been changed or removed. We recommend to start with a fresh template from config/config.php.dist and migrate the settings you require to the new config file manually. 
-  Configuration options that have been removed: admin.protectindexpage . Replaced by the admin module which always requires login.
- We expect your module assets to exist in the public/ directory within your module (was: www/ ). 
- The following classes have been migrated to non-static: \SimpleSAML\Utils\HTTP 